### PR TITLE
add support for Account-Email header

### DIFF
--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -22,12 +22,13 @@ class Pingdom(object):
         * longlimit -- String containing long api rate limit details
     """
 
-    def __init__(self, username, password, apikey, pushchanges=True,
-                 server=server_address):
+    def __init__(self, username, password, apikey, accountemail=None,
+                 pushchanges=True, server=server_address):
         self.pushChanges = pushchanges
         self.username = username
         self.password = password
         self.apikey = apikey
+        self.accountemail = accountemail
         self.url = '%s/api/%s/' % (server, api_version)
         self.shortlimit = ''
         self.longlimit = ''
@@ -35,23 +36,27 @@ class Pingdom(object):
     def request(self, method, url, parameters=dict()):
         """Requests wrapper function"""
 
+        headers = {'App-Key': self.apikey}
+        if self.accountemail:
+            headers.update({'Account-Email': self.accountemail})
+
         # Method selection handling
         if method.upper() == 'GET':
             response = requests.get(self.url + url, params=parameters,
                                     auth=(self.username, self.password),
-                                    headers={'App-Key': self.apikey})
+                                    headers=headers)
         elif method.upper() == 'POST':
             response = requests.post(self.url + url, params=parameters,
                                      auth=(self.username, self.password),
-                                     headers={'App-Key': self.apikey})
+                                     headers=headers)
         elif method.upper() == 'PUT':
             response = requests.put(self.url + url, params=parameters,
                                     auth=(self.username, self.password),
-                                    headers={'App-Key': self.apikey})
+                                    headers=headers)
         elif method.upper() == 'DELETE':
             response = requests.delete(self.url + url, params=parameters,
                                        auth=(self.username, self.password),
-                                       headers={'App-Key': self.apikey})
+                                       headers=headers)
         else:
             raise Exception("Invalid method in pingdom request")
 


### PR DESCRIPTION
If your pingdom account has multiple users you can auth to the API as your account, but you have to send a special header with the email address of the account owner.  Pingdom's docs say this is a feature...

Docs: https://www.pingdom.com/features/api/documentation/#multi-user+authentication

Pull request adds support for this header in the main constructor so connecting is still 1 line of code.  I'm using the modified library in my project and it works as expected.
