### PR TITLE
use_legacy_notifications: create checks without BeepManager

### DIFF
--- a/pingdomlib/check.py
+++ b/pingdomlib/check.py
@@ -32,7 +32,9 @@ class PingdomCheck(object):
         * sendnotificationwhendown -- Send notification when down this many
                                        times
         * notifyagainevery -- Notify again every n result
-        * notifywhenbackup -- Notify when back up again"""
+        * notifywhenbackup -- Notify when back up again
+        * use_legacy_notifications -- Use the old notifications instead of BeepManager
+    """
 
     def __init__(self, instantiator, checkinfo=dict()):
         self.pingdom = instantiator
@@ -44,7 +46,8 @@ class PingdomCheck(object):
                     'sendtotwitter', 'sendtoiphone', 'paused',
                     'sendnotificationwhendown', 'notifyagainevery',
                     'notifywhenbackup', 'created', 'type', 'hostname',
-                    'status', 'lasterrortime', 'lasttesttime']:
+                    'status', 'lasterrortime', 'lasttesttime',
+                    'use_legacy_notifications']:
             self.getDetails()
             return getattr(self, attr)
         else:
@@ -60,7 +63,8 @@ class PingdomCheck(object):
                    'lasterrortime', 'lasttesttime', 'url', 'encryption',
                    'port', 'auth', 'shouldcontain', 'shouldnotcontain',
                    'postdata', 'additionalurls', 'stringtosend',
-                   'stringtoexpect', 'expectedip', 'nameserver']:
+                   'stringtoexpect', 'expectedip', 'nameserver',
+                   'use_legacy_notifications']:
             if self.pingdom.pushChanges:
                 self.modify(**{key: value})
             else:
@@ -203,6 +207,9 @@ class PingdomCheck(object):
             * notifywhenbackup -- Notify when back up again
                     Type: Boolean
 
+            * use_legacy_notifications -- Use old notifications instead of BeepManager
+                    Type: Boolean
+
         HTTP check options:
 
             * url -- Target path on server
@@ -333,7 +340,7 @@ class PingdomCheck(object):
                            'encryption', 'port', 'auth', 'shouldcontain',
                            'shouldnotcontain', 'postdata', 'additionalurls',
                            'stringtosend', 'stringtoexpect', 'expectedip',
-                           'nameserver']:
+                           'nameserver', 'use_legacy_notifications']:
                 sys.stderr.write("'%s'" % key + ' is not a valid argument of' +
                                  '<PingdomCheck>.modify()\n')
 

--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -263,6 +263,11 @@ class Pingdom(object):
                     Type: Boolean
                     Default: True
 
+            * use_legacy_notifications -- Use the old notifications instead of
+                BeepManager
+                    Type: Boolean
+                    Default: False
+
         HTTP check options:
 
             * url -- Target path on server
@@ -423,7 +428,8 @@ class Pingdom(object):
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'url',
                                'encryption', 'port', 'auth', 'shouldcontain',
-                               'shouldnotcontain', 'postdata']:
+                               'shouldnotcontain', 'postdata',
+                               'use_legacy_notifications']:
                     if key.startswith('requestheader') is not True:
                         sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                          'argument of newCheck() for type ' +
@@ -436,7 +442,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'url',
-                               'encryption', 'port', 'auth', 'additionalurls']:
+                               'encryption', 'port', 'auth', 'additionalurls',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'httpcustom'\n")
@@ -448,7 +455,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'port',
-                               'stringtosend', 'stringtoexpect']:
+                               'stringtosend', 'stringtoexpect',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'tcp'\n")
@@ -459,7 +467,8 @@ class Pingdom(object):
                                'sendtoemail', 'sendtosms', 'sendtotwitter',
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
-                               'notifywhenbackup', 'type', 'hostname']:
+                               'notifywhenbackup', 'type', 'hostname',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'ping'\n")
@@ -471,7 +480,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname',
-                               'expectedip', 'nameserver']:
+                               'expectedip', 'nameserver',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'dns'\n")
@@ -483,7 +493,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'port',
-                               'stringtosend', 'stringtoexpect']:
+                               'stringtosend', 'stringtoexpect',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'udp'\n")
@@ -495,7 +506,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'port',
-                               'auth', 'stringtoexpect', 'encryption']:
+                               'auth', 'stringtoexpect', 'encryption',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'smtp'\n")
@@ -507,7 +519,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'port',
-                               'stringtoexpect', 'encryption']:
+                               'stringtoexpect', 'encryption',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'pop3'\n")
@@ -519,7 +532,8 @@ class Pingdom(object):
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
                                'notifywhenbackup', 'type', 'hostname', 'port',
-                               'stringtoexpect', 'encryption']:
+                               'stringtoexpect', 'encryption',
+                               'use_legacy_notifications']:
                     sys.stderr.write("'%s'" % key + ' is not a valid ' +
                                      'argument of newCheck() for type ' +
                                      "'imap'\n")


### PR DESCRIPTION
Pingdom introduced BeepManager, which basically breaks API compatibility for newly created checks. They have an undocumented setting that lets checks be created wit old style notifications instead of BeepManager.
This PR makes it possible to create checks with an extra parameter. Default is to adopt new style checks, i.e. use BeepManager.
