### PR TITLE
If use_legacy_notifications is True, set to 'true'

### DIFF
--- a/pingdomlib/check.py
+++ b/pingdomlib/check.py
@@ -352,6 +352,12 @@ class PingdomCheck(object):
                 sys.stderr.write("'%s'" % key + ' is not a valid argument of' +
                                  '<PingdomCheck>.modify()\n')
 
+        # Pingdom only accepts the literal string "true" as valid true argument.
+        # However, requests will turn a literal True into 1 when building requests
+        # params. That is confusing to users, so fix it here.
+        if kwargs.get("use_legacy_notifications"):
+            kwargs["use_legacy_notifications"] = "true"
+
         response = self.pingdom.request("PUT", 'checks/%s' % self.id, kwargs)
 
         return response.json()['message']


### PR DESCRIPTION
Andreas Larsson from Pingdom Support says:

```
I'm afraid I can't really see anything wrong with [your request] Allard, 

A request that looks like this:

api.pingdom.com/api/2.0/checks/<checkid>?sendnotificationwhendown=<minutes>&use_legacy_notifications=true

Will work to modify it, might it be that you should change use_legacy_notifications=1 to use_legacy_notifications=true instead?

Can't really troubleshoot third party tools like this but it's what I suspect at least.
```

And yes, it seems like `requests` is formulating a form POST, and turning `True` values into the integer `1`. This is not accepted by Pingdom. It is very intuitive to set these values to `True`, not `"true"`, so I'd like to translate this value.

It might be generic to all boolean values, but I don't really know. 
