### PR TITLE
fill in missing attributes with None

### DIFF
--- a/pingdomlib/check.py
+++ b/pingdomlib/check.py
@@ -41,18 +41,20 @@ class PingdomCheck(object):
         * use_legacy_notifications -- Use the old notifications instead of BeepManager
     """
 
+    _detail_keys = ['name', 'resolution', 'sendtoemail', 'sendtosms',
+                    'sendtotwitter', 'sendtoiphone', 'paused',
+                    'sendnotificationwhendown', 'notifyagainevery',
+                    'notifywhenbackup', 'created', 'type', 'hostname',
+                    'status', 'lasterrortime', 'lasttesttime',
+                    'use_legacy_notifications']
+
     def __init__(self, instantiator, checkinfo=dict()):
         self.pingdom = instantiator
         self.__addDetails__(checkinfo)
 
     def __getattr__(self, attr):
         # Pull variables from pingdom if unset
-        if attr in ['name', 'resolution', 'sendtoemail', 'sendtosms',
-                    'sendtotwitter', 'sendtoiphone', 'paused',
-                    'sendnotificationwhendown', 'notifyagainevery',
-                    'notifywhenbackup', 'created', 'type', 'hostname',
-                    'status', 'lasterrortime', 'lasttesttime',
-                    'use_legacy_notifications']:
+        if attr in self._detail_keys:
             self.getDetails()
             return getattr(self, attr)
         else:
@@ -157,6 +159,11 @@ class PingdomCheck(object):
             else:
                 # Store other key value pairs as attributes
                 object.__setattr__(self, key, checkinfo[key])
+
+        # back-fill missing keys (if any)
+        missing_keys = list(set(self._detail_keys) - set(checkinfo.keys()))
+        for key in missing_keys:
+            object.__setattr__(self, key, None)
 
         if 'status' in checkinfo and checkinfo['status'] == 'paused':
             object.__setattr__(self, 'paused', True)

--- a/pingdomlib/check.py
+++ b/pingdomlib/check.py
@@ -42,11 +42,11 @@ class PingdomCheck(object):
     """
 
     _detail_keys = ['name', 'resolution', 'sendtoemail', 'sendtosms',
-                    'sendtotwitter', 'sendtoiphone', 'paused',
+                    'sendtotwitter', 'sendtoiphone', 'paused', 'contactids',
                     'sendnotificationwhendown', 'notifyagainevery',
                     'notifywhenbackup', 'created', 'type', 'hostname',
                     'status', 'lasterrortime', 'lasttesttime',
-                    'use_legacy_notifications']
+                    'use_legacy_notifications',]
 
     def __init__(self, instantiator, checkinfo=dict()):
         self.pingdom = instantiator


### PR DESCRIPTION
Addresses https://github.com/KennethWilke/PingdomLib/issues/15, when a check is initially loaded (using `getChecks`) if there are missing attributes in the response from Pingdom, the attribute will be added with a `None` value:

```
In [4]: for check in checks:
   ...:     print check.lasterrortime
   ...:     
1420826328
1421081819
None
1421081761
1420862042
1421081811
None
1421081814
None
1421081826
None
1421081828
```