### PR TITLE
Bool pre-serialization

### DIFF
--- a/pingdomlib/check.py
+++ b/pingdomlib/check.py
@@ -357,18 +357,12 @@ class PingdomCheck(object):
                 sys.stderr.write("'%s'" % key + ' is not a valid argument of' +
                                  '<PingdomCheck>.modify()\n')
 
-        # Pingdom only accepts the literal string "true" as valid true argument.
-        # However, requests will turn a literal True into 1 when building requests
-        # params. That is confusing to users, so fix it here.
-        if kwargs.get("use_legacy_notifications") in (True, 1):
-            kwargs["use_legacy_notifications"] = "true"
-
         # If one of the legacy parameters is used, it is required to set the legacy flag.
         # https://github.com/KennethWilke/PingdomLib/issues/12
         if any([k for k in kwargs if k in legacy_notification_parameters]):
-            if "use_legacy_notifications" in kwargs and kwargs["use_legacy_notifications"] != "true":
-                raise Exception("Cannot set legacy parameter when use_legacy_notifications is not 'true'")
-            kwargs["use_legacy_notifications"] = "true"
+            if "use_legacy_notifications" in kwargs and kwargs["use_legacy_notifications"] != True:
+                raise Exception("Cannot set legacy parameter when use_legacy_notifications is not True")
+            kwargs["use_legacy_notifications"] = True
 
         response = self.pingdom.request("PUT", 'checks/%s' % self.id, kwargs)
 

--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -33,8 +33,18 @@ class Pingdom(object):
         self.shortlimit = ''
         self.longlimit = ''
 
+    @staticmethod
+    def _serializeBooleans(params):
+        """"Convert all booleans to lowercase strings"""
+        for k, v in params.iteritems():
+            if isinstance(v, bool):
+                params[k] = str(v).lower()
+
     def request(self, method, url, parameters=dict()):
         """Requests wrapper function"""
+
+        # The requests library uses urllib, which serializes to "True"/"False" while Pingdom requires lowercase
+        self._serializeBooleans(parameters)
 
         headers = {'App-Key': self.apikey}
         if self.accountemail:

--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -36,6 +36,15 @@ class Pingdom(object):
     @staticmethod
     def _serializeBooleans(params):
         """"Convert all booleans to lowercase strings"""
+        serialized = {}
+        for name, value in params.iteritems():
+            if value is True:
+                value = 'true'
+            elif value is False:
+                value = 'false'
+            serialized[name] = value
+        return serialized
+
         for k, v in params.iteritems():
             if isinstance(v, bool):
                 params[k] = str(v).lower()
@@ -44,7 +53,7 @@ class Pingdom(object):
         """Requests wrapper function"""
 
         # The requests library uses urllib, which serializes to "True"/"False" while Pingdom requires lowercase
-        self._serializeBooleans(parameters)
+        parameters = self._serializeBooleans(parameters)
 
         headers = {'App-Key': self.apikey}
         if self.accountemail:


### PR DESCRIPTION
This doesn't work: ```check.averages(includeuptime=True)```
This works: ```check.averages(includeuptime='true')```

The requests library uses urllib, which serializes to "True"/"False" while Pingdom requires lowercase. 

Implements a pre-serialization, and handles the previous ugly corner case for "use_legacy_notification" in a generic way.
