### PR TITLE
Move from iteritems() to items() so it works with python3

### DIFF
--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -37,7 +37,7 @@ class Pingdom(object):
     def _serializeBooleans(params):
         """"Convert all booleans to lowercase strings"""
         serialized = {}
-        for name, value in params.iteritems():
+        for name, value in params.items():
             if value is True:
                 value = 'true'
             elif value is False:
@@ -45,7 +45,7 @@ class Pingdom(object):
             serialized[name] = value
         return serialized
 
-        for k, v in params.iteritems():
+        for k, v in params.items():
             if isinstance(v, bool):
                 params[k] = str(v).lower()
 


### PR DESCRIPTION
Hi,

this change _seems_ to work both with python2 and python3. Without this change the library doens't work on python3 and fails with the following error:

```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.5/site-packages/errbot/core.py", line 451, in _execute_and_send
    for reply in replies:
  File "/app/plugins/pingdom/pingdom.py", line 35, in pingdom_status
    checks = api.getChecks()
  File "/app/.heroku/python/lib/python3.5/site-packages/pingdomlib/pingdom.py", line 212, in getChecks
    response = self.request('GET', 'checks', parameters)
  File "/app/.heroku/python/lib/python3.5/site-packages/pingdomlib/pingdom.py", line 56, in request
    parameters = self._serializeBooleans(parameters)
  File "/app/.heroku/python/lib/python3.5/site-packages/pingdomlib/pingdom.py", line 40, in _serializeBooleans
    for name, value in params.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
```
